### PR TITLE
feat: validate forms only once (#58)

### DIFF
--- a/lib/formz.dart
+++ b/lib/formz.dart
@@ -97,14 +97,14 @@ abstract class FormzInput<T, E> {
   E? get error => _checkResultsMap();
 
   E? _checkResultsMap() {
-    dynamic error;
-    if (!_forms._resMap.containsKey(this)) {
+    E? error;
+    if (!_forms<T, E>().resMap.containsKey(this)) {
       error = validator(value);
-      _forms._resMap.addAll({this: error});
+      _forms<T, E>().resMap[this] = error;
     } else {
-      error = _forms._resMap[this];
+      error = _forms<T, E>().resMap[this];
     }
-    return error as E?;
+    return error;
   }
 
   /// The error to display if the [FormzInput] value
@@ -115,7 +115,8 @@ abstract class FormzInput<T, E> {
   /// [value] is invalid and `null` otherwise.
   E? validator(T value);
 
-  static final _forms = _Results();
+  static _Results<T, E> _forms<T, E>() =>
+  _Results<T, E>();
 
   @override
   int get hashCode => Object.hashAll([value, isPure]);
@@ -136,8 +137,10 @@ abstract class FormzInput<T, E> {
   }
 }
 
-class _Results<E> {
-  final Map<FormzInput, E?> _resMap = Map();
+class _Results<T, E> {
+  final Map<FormzInput<T, E>, E?> _resMap = {};
+
+  Map<FormzInput<T, E>, E?> get resMap => _resMap;
 }
 
 /// Class which contains methods that help manipulate and manage

--- a/lib/formz.dart
+++ b/lib/formz.dart
@@ -85,7 +85,7 @@ abstract class FormzInput<T, E> {
   ///
   /// Returns `true` if `validator` returns `null` for the
   /// current [FormzInput] value and `false` otherwise.
-  bool get isValid => validator(value) == null;
+  bool get isValid => _checkResultsMap() == null;
 
   /// Whether the [FormzInput] value is not valid.
   /// A value is invalid when the overridden `validator`
@@ -94,7 +94,18 @@ abstract class FormzInput<T, E> {
 
   /// Returns a validation error if the [FormzInput] is invalid.
   /// Returns `null` if the [FormzInput] is valid.
-  E? get error => validator(value);
+  E? get error => _checkResultsMap();
+
+  E? _checkResultsMap() {
+    dynamic error;
+    if (!_forms._resMap.containsKey(this)) {
+      error = validator(value);
+      _forms._resMap.addAll({this: error});
+    } else {
+      error = _forms._resMap[this];
+    }
+    return error as E?;
+  }
 
   /// The error to display if the [FormzInput] value
   /// is not valid and has been modified.
@@ -103,6 +114,8 @@ abstract class FormzInput<T, E> {
   /// A function that must return a validation error if the provided
   /// [value] is invalid and `null` otherwise.
   E? validator(T value);
+
+  static final _forms = _Results();
 
   @override
   int get hashCode => Object.hashAll([value, isPure]);
@@ -121,6 +134,10 @@ abstract class FormzInput<T, E> {
         ? '''FormzInput<$T, $E>.pure(value: $value, isValid: $isValid, error: $error)'''
         : '''FormzInput<$T, $E>.dirty(value: $value, isValid: $isValid, error: $error)''';
   }
+}
+
+class _Results<E> {
+  final Map<FormzInput, E?> _resMap = Map();
 }
 
 /// Class which contains methods that help manipulate and manage


### PR DESCRIPTION
## Description

This adds a map which stores the errors from calls to the validator. Then it can be used to access the error in subsequent calls without evaluating it again.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
