### PR TITLE
feat: add FormzInputErrorCacheMixin mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,28 +100,26 @@ void main() {
 
 ## Caching validation results
 
-For cases where the validator method has an expensive implementation, one could cache the validation result on a `late final` field. 
+For cases where the validator method has an expensive implementation, consider using the `FormzInputErrorCacheMixin` mixin to cache the `error` result and improve performance.
 
 ```dart
 import 'package:formz/formz.dart';
 
 enum EmailValidationError { invalid }
 
-class Email extends FormzInput<String, EmailValidationError> {
+class Email extends FormzInput<String, EmailValidationError>
+    with FormzInputErrorCacheMixin {
   Email.pure([super.value = '']) : super.pure();
 
   Email.dirty([super.value = '']) : super.dirty();
 
   static final _emailRegExp = RegExp(
-    r'^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$',
+    r'^[a-zA-Z\d.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z\d-]+(?:\.[a-zA-Z\d-]+)*$',
   );
-
-  late final validationResultCache =
-  _emailRegExp.hasMatch(value) ? null : EmailValidationError.invalid;
 
   @override
   EmailValidationError? validator(String value) {
-    return validationResultCache;
+    return _emailRegExp.hasMatch(value) ? null : EmailValidationError.invalid;
   }
 }
 ```

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -190,21 +190,19 @@ class MyFormState with FormzMixin {
 
 enum EmailValidationError { invalid }
 
-class Email extends FormzInput<String, EmailValidationError> {
+class Email extends FormzInput<String, EmailValidationError>
+    with FormzInputErrorCacheMixin {
   Email.pure([super.value = '']) : super.pure();
 
   Email.dirty([super.value = '']) : super.dirty();
 
   static final _emailRegExp = RegExp(
-    r'^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$',
+    r'^[a-zA-Z\d.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z\d-]+(?:\.[a-zA-Z\d-]+)*$',
   );
-
-  late final validationResultCache =
-      _emailRegExp.hasMatch(value) ? null : EmailValidationError.invalid;
 
   @override
   EmailValidationError? validator(String value) {
-    return validationResultCache;
+    return _emailRegExp.hasMatch(value) ? null : EmailValidationError.invalid;
   }
 }
 

--- a/lib/formz.dart
+++ b/lib/formz.dart
@@ -123,6 +123,19 @@ abstract class FormzInput<T, E> {
   }
 }
 
+/// Mixin for [FormzInput] that caches the [error] result of the [validator].
+/// Use this mixin when implementations that make expensive computations are
+/// used, such as those involving regular expressions.
+mixin FormzInputErrorCacheMixin<T, E> on FormzInput<T, E> {
+  late final E? _error = validator(value);
+
+  @override
+  E? get error => _error;
+
+  @override
+  bool get isValid => _error == null;
+}
+
 /// Class which contains methods that help manipulate and manage
 /// validity of [FormzInput] instances.
 class Formz {


### PR DESCRIPTION
## Description

#78 PR closed #58 issue but I think using a generic and easy to add `FormzInputErrorCacheMixin` mixin is much more developer friendly than creating my own cache over and over again when a new `FormzInput` class is created.

closes #58

<!--- Describe your changes in detail -->

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
