### PR TITLE
feat: add purety check to  FormzMixin

### DIFF
--- a/lib/formz.dart
+++ b/lib/formz.dart
@@ -186,7 +186,7 @@ mixin FormzMixin {
   /// Whether the [FormzInput] values are not all valid.
   bool get isNotValid => !isValid;
 
-  ///Whether all of the [FormzInput] are pure
+  /// Whether all of the [FormzInput] are pure.
   bool get isPure => Formz.isPure(inputs);
 
   ///Whether all of the [FormzInput] are pure

--- a/lib/formz.dart
+++ b/lib/formz.dart
@@ -151,6 +151,12 @@ class Formz {
   static bool validate(List<FormzInput<dynamic, dynamic>> inputs) {
     return inputs.every((input) => input.isValid);
   }
+
+  /// Returns a [bool] given a list of [FormzInput] indicating whether
+  /// all the inputs are pure
+  static bool isPure(List<FormzInput<dynamic, dynamic>> inputs) {
+    return inputs.every((input) => input.isPure);
+  }
 }
 
 /// Mixin that automatically handles validation of all [FormzInput]s present in
@@ -179,6 +185,12 @@ mixin FormzMixin {
 
   /// Whether the [FormzInput] values are not all valid.
   bool get isNotValid => !isValid;
+
+  ///Whether all of the [FormzInput] are pure
+  bool get isPure => Formz.isPure(inputs);
+
+  ///Whether all of the [FormzInput] are pure
+  bool get isDirty => !isPure;
 
   /// Returns all [FormzInput] instances.
   ///

--- a/lib/formz.dart
+++ b/lib/formz.dart
@@ -153,7 +153,7 @@ class Formz {
   }
 
   /// Returns a [bool] given a list of [FormzInput] indicating whether
-  /// all the inputs are pure
+  /// all the inputs are pure.
   static bool isPure(List<FormzInput<dynamic, dynamic>> inputs) {
     return inputs.every((input) => input.isPure);
   }

--- a/lib/formz.dart
+++ b/lib/formz.dart
@@ -189,7 +189,7 @@ mixin FormzMixin {
   /// Whether all of the [FormzInput] are pure.
   bool get isPure => Formz.isPure(inputs);
 
-  ///Whether all of the [FormzInput] are pure
+  /// Whether all of the [FormzInput] are dirty.
   bool get isDirty => !isPure;
 
   /// Returns all [FormzInput] instances.

--- a/test/formz_test.dart
+++ b/test/formz_test.dart
@@ -26,6 +26,18 @@ void main() {
         expect(form.isValid, isTrue);
         expect(form.isNotValid, isFalse);
       });
+
+      test('is pure when none of the inputs were touched', () {
+        final form = NameInputFormzMixin();
+        expect(form.isPure, isTrue);
+        expect(form.isDirty, isFalse);
+      });
+
+      test('is dirty when one or multiple inputs were touched', () {
+        final form = NameInputFormzMixin(name: const NameInput.dirty());
+        expect(form.isDirty, isTrue);
+        expect(form.isPure, isFalse);
+      });
     });
 
     group('FormzInputErrorCacheMixin', () {


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Added two methods to the FormzMixin for checking the embedded inputs purety, as requested in #82 as well as the tests that covers them.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
