### PR TITLE
ci: use flutter_package workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,12 +13,8 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1
 
   build:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1.11.0
-
-  example:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
-      working_directory: example
       flutter_channel: stable
       flutter_version: 3.13.0
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,10 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1
 
   build:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1.11.0
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+    with:
+      flutter_channel: stable
+      flutter_version: 3.7.3
 
   spell-check:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/spell_check.yml@v1.11.0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       flutter_channel: stable
-      flutter_version: 3.7.3
+      flutter_version: 3.13.0
 
   spell-check:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/spell_check.yml@v1.11.0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,8 +13,12 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1
 
   build:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1.11.0
+
+  example:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
+      working_directory: example
       flutter_channel: stable
       flutter_version: 3.13.0
 


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

 The [CI is broken](https://github.com/VeryGoodOpenSource/formz/actions/runs/6108997764/job/16579110212?pr=100) due to `dart pub get` reporting: 

> Because example depends on flutter_test from sdk which doesn't exist (the Flutter SDK is not available), version solving failed.

This is because the example depends on flutter and `dart pub get` attempts to get on `/example`.

Changes:
- Updates workflow to use flutter_package over dart_package.
- Sets flutter_package workflow to use Flutter 3.13.0

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [X] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
